### PR TITLE
Resolve library home correctly when installed as haxelib

### DIFF
--- a/src/modular/js/JsGenerator.hx
+++ b/src/modular/js/JsGenerator.hx
@@ -53,7 +53,7 @@ class JsGenerator
 			var path = FileSystem.absolutePath(cp);
 			var index = path.indexOf('modular-js');
 			if (index != -1) {
-				jsStubPath = path.substr(0, index) + 'modular-js/js';
+				jsStubPath = Path.join([path, '..', 'js']);
 				break;
 			}
 		}


### PR DESCRIPTION
Currently when installed through haxelib the value of `jsStubPath` resolves to `[...]haxelib/modular-js/js` which is missing the haxelib version part of the path.

This fixes resolution of that path by starting at the classpath `[...]/src` going up one level to `../js`
